### PR TITLE
fixes #56

### DIFF
--- a/lib/ui/datepicker/datepicker.js
+++ b/lib/ui/datepicker/datepicker.js
@@ -164,8 +164,15 @@
           $log.info('avDatepicker changeDate {0}', [e]);
         });
 
-        ngModel.$parsers.push(avDatepicker.viewToModel); // (view to model)
-        ngModel.$formatters.unshift(avDatepicker.modelToView);  // (model to view)
+        // (view to model)
+        ngModel.$parsers.push(avDatepicker.viewToModel);
+
+        // (model to view) - added to end of formatters array
+        // because they are processed in reverse order.
+        // if the model is in Date format and send to the validation framework
+        // prior to getting converted to the expected $viewValue format,
+        // the validation will fail.
+        ngModel.$formatters.push(avDatepicker.modelToView);
 
         var _$render = ngModel.$render;
         ngModel.$render = function() {

--- a/lib/ui/validation/adapter-bootstrap.js
+++ b/lib/ui/validation/adapter-bootstrap.js
@@ -83,7 +83,7 @@
         $timeout(function() {
           // scroll to offset top of first error minus the offset of the navbars
           $('body, html').animate({scrollTop: $target.offset().top - offset}, 'fast');
-        });
+        }, 0, false);
       }
     };
   });

--- a/lib/ui/validation/field.js
+++ b/lib/ui/validation/field.js
@@ -161,7 +161,9 @@
         // (view to model)
         ngModel.$parsers.push(avValField.validateView);
 
-        // (model to view) - potentially allow other formatter to run first
+        // (model to view) - added to beginning of array because formatters
+        // are processed in reverse order thus allowing the model to be transformed
+        // before the validation framework check for validity.
         ngModel.$formatters.unshift(avValField.validateModel);
 
         scope.$on(AV_VAL.EVENTS.REVALIDATE, function() {

--- a/lib/ui/validation/tests/field-spec.js
+++ b/lib/ui/validation/tests/field-spec.js
@@ -17,6 +17,10 @@ describe('avValField', function() {
             'required': {
               'message': 'Last name is required.'
             }
+          },
+          'dateFormat': {
+            'format': 'MM/DD/YYYY',
+            'message': 'Format needs to be MM/DD/YYYY'
           }
         }
       });
@@ -39,6 +43,7 @@ describe('avValField', function() {
       '<input data-ng-model="demo.lastName" name="lastName" type="text" data-av-val-field="lastName"/>' +
       '<input data-ng-model="demo.city" name="city" type="text"/>' +
       '<input data-ng-model="demo.state" name="state" type="text" required/>' +
+      '<input data-ng-model="demo.date" name="date" type="text" data-av-datepicker data-av-val-field="dateFormat">' +
     '</form>';
 
     $el = availity.mock.compileDirective(template);
@@ -59,6 +64,18 @@ describe('avValField', function() {
 
     expect(availity.mock.$scope.myForm.lastName.$invalid).toBe(true);
     expect(availity.mock.$scope.demo.lastName).toBeUndefined();
+  });
+
+  describe('with avDatePicker', function() {
+
+    it('should validate model using default format', function() {
+      availity.mock.$scope.demo.date = new Date(1986, 0, 22);
+      availity.mock.$scope.$digest();
+
+      expect(availity.mock.$scope.myForm.date.$invalid).toBe(false);
+      expect(availity.mock.$scope.myForm.date.$viewValue).toBe('01/22/1986');
+    });
+
   });
 
 });


### PR DESCRIPTION
add validation formatter to the end of the `$formatters` pipeline so that other formatters can transform the model into the expected validation contraint format. closes #56 