### PR TITLE
Added support for Karma OSX reporter when available

### DIFF
--- a/gulp/tasks/test.js
+++ b/gulp/tasks/test.js
@@ -4,6 +4,13 @@ var gutil = require('gulp-util');
 
 var config = require('../config');
 
+var hasKarmaOsxReporter = true;
+try {
+  require('karma-osx-reporter');
+} catch(err) {
+  hasKarmaOsxReporter = false;
+}
+
 var files = config.test.src
   .concat(config.lib.src)
   .concat(config.ui.src)
@@ -36,11 +43,15 @@ gulp.task('test:sauce', ['lint'], function (done) {
 
 gulp.task('test:server', ['lint'], function() {
   var karma = require('karma').server;
+  var reporters = ['progress'];
+  if(hasKarmaOsxReporter) {
+    reporters.push('osx');
+  }
   karma.start({
     configFile: path.join(config.project.path, 'karma.conf.js'),
     browsers: ['Chrome'],
     files: files,
-    reporters: ['progress'],
+    reporters: reporters,
     autoWatch: true,
     singleRun: false
   }, function(code) {

--- a/package.json
+++ b/package.json
@@ -83,5 +83,8 @@
     "semver": "^4.3.3",
     "sinon": "1.12",
     "underscore.string": "^3.0.3"
+  },
+  "optionalDependencies": {
+    "karma-osx-reporter": "*"
   }
 }


### PR DESCRIPTION
This will automatically integrate karma-osx-reporter when available.  This needs Windows testing before merging.