### PR TITLE
Corrected a condition for the dropdown ajax handling

### DIFF
--- a/lib/ui/dropdown/dropdown.js
+++ b/lib/ui/dropdown/dropdown.js
@@ -225,7 +225,7 @@
 
           // special case since the ajax handling doesn't bind to the model correctly
           // this has to do with select2 (v3.5.2) using a hidden field instead of a select for ajax
-          if(!_.isNull(avDropdown.options.query)) {
+          if(avDropdown.options.query) {
             $timeout(function() {
               ngModel.$setViewValue(e.added);
             });


### PR DESCRIPTION
This condition was coming up as truthy for all dropdowns that don't use ajax to populate their options.  This ended up causing them to incorrectly set selections to the ng-model value.  I couldn't create a branch on this repo so a pull request to master is all I've got.