### PR TITLE
bugfix: Adding format valid check to date range

### DIFF
--- a/lib/core/validation/validators/validator-date-range-spec.js
+++ b/lib/core/validation/validators/validator-date-range-spec.js
@@ -62,8 +62,14 @@ describe('avValDateRange', function () {
     expect(dateRange.validate('06292015', rules)).toBe(false);
     expect(dateRange.validate('05012015', rulesFromTo)).toBe(false);
     expect(dateRange.validate('05162015', rulesFromTo)).toBe(false);
-  });
+    //Format Checks
+    expect(dateRange.validate('04452015', rules)).toBe(false);
+    expect(dateRange.validate('04462015', rules)).toBe(false);
+    expect(dateRange.validate('04472015', rules)).toBe(false);
+    expect(dateRange.validate('17132014', rulesFromTo)).toBe(false);
+    expect(dateRange.validate('17142014', rulesFromTo)).toBe(false);
 
+  });
 
 
 });

--- a/lib/core/validation/validators/validator-date-range.js
+++ b/lib/core/validation/validators/validator-date-range.js
@@ -56,7 +56,7 @@
           startDate = moment(rules.start.value, rules.format);
           endDate = validator.setMax(moment(rules.end.value, rules.format));
         }
-        return date.isBetween(startDate, endDate, 'day') || date.isSame(startDate, 'day') || date.isSame(endDate, 'day');
+        return date.isValid() && date.isBetween(startDate, endDate, 'day') || date.isSame(startDate, 'day') || date.isSame(endDate, 'day');
       },
 
       validate: function(value, rule) {


### PR DESCRIPTION
This is adding a format check to the dateRange validator. I ran into an issue where I had MM/DD/YYYY as my format in dateRange however a date such as 13/01/2014 was valid and converted to 01/01/2015 when validating. This also happened for days such as 06/33/2015 would validate as 07/02/2015.