### PR TITLE
breadcrumbs are now initializing

### DIFF
--- a/lib/ui/breadcrumbs/breadcrumbs.js
+++ b/lib/ui/breadcrumbs/breadcrumbs.js
@@ -50,6 +50,8 @@
       templateUrl: AV_BREADCRUMBS.TEMPLATE,
       controller: 'AvBreadcrumbsController',
       link: function(scope, element, attrs, AvBreadcrumbsController) {
+        scope.breadcrumbs = AvBreadcrumbsController.getBreadcrumbs();
+
         scope.$on('$stateChangeSuccess', function() {
           scope.breadcrumbs = AvBreadcrumbsController.getBreadcrumbs();
         });

--- a/lib/ui/breadcrumbs/tests/breadcrumbs-spec.js
+++ b/lib/ui/breadcrumbs/tests/breadcrumbs-spec.js
@@ -169,6 +169,18 @@ describe('avBreadcrumbs', function() {
 
   describe('avBreadcrumbsDirective', function() {
 
+    it('should initialize breadcrumbs during post-link', function() {
+      var expected = states['parent-state'].data.breadcrumb;
+
+      $state.transitionTo('parent-state', undefined, { notify: false });
+      $rootScope.$digest();
+      availity.mock.compileDirective(template);
+
+      var breadcrumbs = availity.mock.$scope.breadcrumbs;
+      expect(breadcrumbs.length).toBeEqual(1);
+      expect(breadcrumbs[0]).toBeEqual(expected);
+    });
+
     it('should update breadcrumbs on $stateChangeSuccess', function() {
 
       var expectedParent = states['parent-state'].data.breadcrumb;
@@ -176,9 +188,9 @@ describe('avBreadcrumbs', function() {
       var expectedChild2 = states['child-state2'].data.breadcrumb;
 
       $state.transitionTo('child-state1');
-      $el = availity.mock.compileDirective(template);
+      availity.mock.compileDirective(template);
 
-      var breadcrumbs = $el.data('$avBreadcrumbsController').getBreadcrumbs();
+      var breadcrumbs = availity.mock.$scope.breadcrumbs;
       expect(breadcrumbs.length).toBeEqual(2);
       expect(breadcrumbs[0]).toBeEqual(expectedParent);
       expect(breadcrumbs[1]).toBeEqual(expectedChild1);
@@ -186,7 +198,7 @@ describe('avBreadcrumbs', function() {
       $state.transitionTo('child-state2');
       $rootScope.$digest();
 
-      breadcrumbs = $el.data('$avBreadcrumbsController').getBreadcrumbs();
+      breadcrumbs = availity.mock.$scope.breadcrumbs;
       expect(breadcrumbs.length).toBeEqual(2);
       expect(breadcrumbs[0]).toBeEqual(expectedParent);
       expect(breadcrumbs[1]).toBeEqual(expectedChild2);


### PR DESCRIPTION
Breadcrumbs weren't being set until a $stateChangeSuccess occurred. Now they are set initially then updated when $stateChangeSuccess occurs.