### PR TITLE
add badge directive and approximate filter

### DIFF
--- a/gulp/config.js
+++ b/gulp/config.js
@@ -98,7 +98,8 @@ module.exports = {
       './lib/ui/permissions/has-permission.js',
       './lib/ui/analytics/analytics.js',
       './lib/ui/placeholder/placeholder.js',
-      './lib/ui/breadcrumbs/breadcrumbs.js'
+      './lib/ui/breadcrumbs/breadcrumbs.js',
+      './lib/ui/filters/approximate.js'
     ],
     specs: './lib/ui/**/*spec.js',
     destDist: './dist',

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -99,7 +99,8 @@ module.exports = {
       './lib/ui/analytics/analytics.js',
       './lib/ui/placeholder/placeholder.js',
       './lib/ui/breadcrumbs/breadcrumbs.js',
-      './lib/ui/filters/approximate.js'
+      './lib/ui/filters/approximate.js',
+      './lib/ui/badge/badge.js'
     ],
     specs: './lib/ui/**/*spec.js',
     destDist: './dist',

--- a/lib/ui/badge/badge-tpl.html
+++ b/lib/ui/badge/badge-tpl.html
@@ -1,0 +1,1 @@
+<span data-ng-if="showWhenZero || count > 0" data-ng-bind="count | avApproximate"></span>

--- a/lib/ui/badge/badge.js
+++ b/lib/ui/badge/badge.js
@@ -1,0 +1,40 @@
+(function(root) {
+  'use strict';
+
+  var availity = root.availity;
+
+  availity.ui.constant('AV_BADGE', {
+    COLOR: null,
+    DEFAULT_CLASS: 'badge',
+    SHOW_WHEN_ZERO: false,
+    TEMPLATE: 'ui/badge/badge-tpl.html'
+  });
+
+  function badgeDirective(AV_BADGE) {
+
+    return {
+      scope: {
+        color: '@',
+        count: '=avBadge',
+        showWhenZero: '@'
+      },
+      templateUrl: AV_BADGE.TEMPLATE,
+      link: function(scope, element) {
+        scope.color = scope.color || AV_BADGE.COLOR;
+        scope.showWhenZero = scope.showWhenZero || AV_BADGE.SHOW_WHEN_ZERO;
+
+        var classes = [];
+        classes.push(AV_BADGE.DEFAULT_CLASS);
+        if(scope.color) {
+          classes.push(scope.color);
+        }
+
+        element.addClass(classes.join(' '));
+      }
+    };
+  }
+
+  badgeDirective.$inject = ['AV_BADGE'];
+  availity.ui.directive('avBadge', badgeDirective);
+
+})(window);

--- a/lib/ui/badge/docs/badge-ui-demo.html
+++ b/lib/ui/badge/docs/badge-ui-demo.html
@@ -1,0 +1,26 @@
+---
+title: Badges
+---
+<div>
+  <p>Badges display the approximation of the given value.</p>
+  <blockquote>Badges hide when value is falsey unless specified otherwise.</blockquote>
+
+  <div class="guide-example">
+    <p>Alerts <span data-av-badge="42"></span></p>
+    <p>Alerts <span data-av-badge="1000" data-color="badge-success"></span></p>
+
+    <p>
+      <button class="btn btn-primary" type="button">
+        Messages <span data-av-badge="42"></span>
+      </button>
+    </p>
+  </div>
+  <code class="language-markup">
+    <p>Alerts <span data-av-badge="42"></span></p>
+    <p>Alerts <span data-av-badge="1000" data-color="badge-success"></span></p>
+
+    <button class="btn btn-primary" type="button">
+      Messages <span data-av-badge="42"></span>
+    </button>
+  </code>
+</div>

--- a/lib/ui/badge/tests/badge-spec.js
+++ b/lib/ui/badge/tests/badge-spec.js
@@ -1,0 +1,48 @@
+/* global beforeEach, availity, expect, module, inject, describe, it */
+describe('avBadge', function() {
+
+  'use strict';
+
+  var $rootScope;
+  var defaultBadge = {
+    COLOR: 'default-color',
+    DEFAULT_CLASS: 'default-class'
+  };
+
+  beforeEach(function() {
+    module('availity');
+    module('availity.ui');
+  });
+
+  beforeEach(module(function(AV_BADGE) {
+    angular.extend(AV_BADGE, defaultBadge);
+  }));
+
+  beforeEach(inject(function(_$rootScope_, $templateCache) {
+    $rootScope = _$rootScope_;
+    $templateCache.put('ui/badge/badge-tpl.html', '');
+  }));
+
+  availity.mock.directiveSpecHelper();
+  var $el;
+
+  // jscs: disable
+  var fixtures = {
+    'default': '<div av-badge="42"></div>',
+    'color': '<div av-badge="42" data-color="my-color"></div>'
+  };
+  // jscs: enable
+
+  it('should default values', function() {
+    $el = availity.mock.compileDirective(fixtures['default']);
+
+    expect($el.hasClass(defaultBadge.DEFAULT_CLASS)).toBe(true);
+    expect($el.hasClass(defaultBadge.COLOR)).toBe(true);
+  });
+
+  it('should set color', function() {
+    $el = availity.mock.compileDirective(fixtures['color']);
+    expect($el.hasClass('my-color')).toBe(true);
+  });
+
+});

--- a/lib/ui/filters/approximate.js
+++ b/lib/ui/filters/approximate.js
@@ -1,0 +1,25 @@
+(function(root) {
+  'use strict';
+
+  var availity = root.availity;
+
+  availity.ui.filter('avApproximate', function() {
+    var pow = Math.pow;
+    var floor = Math.floor;
+    var abs = Math.abs;
+    var log = Math.log;
+
+    function round(number, precision) {
+      var prec = pow(10, precision);
+      return Math.round(number * prec) / prec;
+    }
+
+    return function (number, precision) {
+      precision = precision || 0;
+      var base = floor(log(abs(number)) / log(1000));
+      var unit = 'kMGTPE'[base - 1];
+      return unit ? round(number / pow(1000, base), precision) + unit : (number || 0);
+    };
+  });
+
+})(window);

--- a/lib/ui/filters/docs/filters-ui-demo.html
+++ b/lib/ui/filters/docs/filters-ui-demo.html
@@ -1,0 +1,35 @@
+---
+title: Filters
+---
+
+<div data-markdown>
+  > Filters can easily be abused and increase chances of performance issues. Use sparingly and on select properties.
+</div>
+
+<div data-ng-controller="FiltersController">
+
+  <h3 class="guide-subsection-title">Approximate</h3>
+
+  <blockquote>
+    An optional precision parameter can be supplied to include decimals within the approximation.
+  </blockquote>
+
+  <div class="guide-example">
+
+    <input type="text"
+           class="form-control"
+           id="approximate"
+           data-placeholder="Enter a large value..."
+           data-ng-model="demo.approximate"
+      />
+
+    <div>
+      <h4>Formatted Value</h4>
+      <p data-ng-bind="demo.approximate | avApproximate"></p>
+    </div>
+  </div>
+  <code class="language-markup">
+    <span data-ng-bind="value | avApproximate"></span>
+    <span data-ng-bind="value | avApproximate: 1"></span>
+  </code>
+</div>

--- a/lib/ui/filters/docs/filters-ui-demo.js
+++ b/lib/ui/filters/docs/filters-ui-demo.js
@@ -1,0 +1,15 @@
+(function(root) {
+
+  'use strict';
+
+  var availity = root.availity;
+
+  availity.demo.controller('FiltersController', function($scope) {
+
+    $scope.demo = {
+      approximate: 1000
+    };
+
+  });
+
+})(window);

--- a/lib/ui/filters/tests/approximate-spec.js
+++ b/lib/ui/filters/tests/approximate-spec.js
@@ -1,4 +1,4 @@
-/* global beforeEach, availity, expect, module, inject, describe, it */
+/* global beforeEach, expect, module, inject, describe, it */
 describe('avApproximate', function() {
 
   'use strict';
@@ -16,33 +16,41 @@ describe('avApproximate', function() {
 
   describe('falsey value tests', function() {
     var falseyValues = [undefined, null, NaN, 0, '', false];
+
+    var test = function() {
+      var actual = approximate(value);
+      expect(actual).toBeEqual(0);
+    };
+
     for(var i = 0; i < falseyValues.length; i++) {
       var value = falseyValues[i];
-      it('should return zero when value is "' + value + '"', function() {
-        var actual = approximate(value);
-        expect(actual).toBeEqual(0);
-      });
+      it('should return zero when value is "' + value + '"', test);
     }
   });
 
   describe('unchanged value tests', function() {
     var values = [1, 100, 999, 1000000000000000000000];
+
+    var test = function() {
+      var actual = approximate(value);
+      expect(actual).toBeEqual(value);
+    };
+
     for(var i = 0; i < values.length; i++) {
       var value = values[i];
-      it('should return value unchanged (' + value + ')', function() {
-        var actual = approximate(value);
-        expect(actual).toBeEqual(value);
-      });
+      it('should return value unchanged (' + value + ')', test);
     }
   });
 
   function baseFormatTest(values, suffix, base) {
+    var test = function() {
+      var actual = approximate(value);
+      expect(actual).toBeEqual(value / base + suffix);
+    };
+
     for(var i = 0; i < values.length; i++) {
       var value = values[i];
-      it('should return with ' + suffix + ' suffix (' + value + ')', function() {
-        var actual = approximate(value);
-        expect(actual).toBeEqual(value / base + suffix);
-      });
+      it('should return with ' + suffix + ' suffix (' + value + ')', test);
     }
   }
 

--- a/lib/ui/filters/tests/approximate-spec.js
+++ b/lib/ui/filters/tests/approximate-spec.js
@@ -1,0 +1,73 @@
+/* global beforeEach, availity, expect, module, inject, describe, it */
+describe('avApproximate', function() {
+
+  'use strict';
+
+  var approximate;
+
+  beforeEach(function() {
+    module('availity');
+    module('availity.ui');
+  });
+
+  beforeEach(inject(function($filter) {
+    approximate = $filter('avApproximate');
+  }));
+
+  describe('falsey value tests', function() {
+    var falseyValues = [undefined, null, NaN, 0, '', false];
+    for(var i = 0; i < falseyValues.length; i++) {
+      var value = falseyValues[i];
+      it('should return zero when value is "' + value + '"', function() {
+        var actual = approximate(value);
+        expect(actual).toBeEqual(0);
+      });
+    }
+  });
+
+  describe('unchanged value tests', function() {
+    var values = [1, 100, 999, 1000000000000000000000];
+    for(var i = 0; i < values.length; i++) {
+      var value = values[i];
+      it('should return value unchanged (' + value + ')', function() {
+        var actual = approximate(value);
+        expect(actual).toBeEqual(value);
+      });
+    }
+  });
+
+  function baseFormatTest(values, suffix, base) {
+    for(var i = 0; i < values.length; i++) {
+      var value = values[i];
+      it('should return with ' + suffix + ' suffix (' + value + ')', function() {
+        var actual = approximate(value);
+        expect(actual).toBeEqual(value / base + suffix);
+      });
+    }
+  }
+
+  describe('kilo- tests', function() {
+    baseFormatTest([1000, 10000, 100000], 'k', 1000);
+  });
+
+  describe('mega- tests', function() {
+    baseFormatTest([1000000, 10000000, 100000000], 'M', 1000000);
+  });
+
+  describe('giga- tests', function() {
+    baseFormatTest([1000000000, 10000000000, 100000000000], 'G', 1000000000);
+  });
+
+  describe('tera- tests', function() {
+    baseFormatTest([1000000000000, 10000000000000, 100000000000000], 'T', 1000000000000);
+  });
+
+  describe('peta- tests', function() {
+    baseFormatTest([1000000000000000, 10000000000000000, 100000000000000000], 'P', 1000000000000000);
+  });
+
+  describe('exa- tests', function() {
+    baseFormatTest([1000000000000000000, 10000000000000000000, 100000000000000000000], 'E', 1000000000000000000);
+  });
+
+});

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     {
       "name": "Robert McGuinness",
       "email": "rob.mcguinness@availity.com"
+    },
+    {
+      "name": "Bobby Bennett",
+      "email": "bbennett8609@gmail.com"
     }
   ],
   "license": "MIT",


### PR DESCRIPTION
The approximate filter will format numbers in a friendly manner e.g. 1,000 -> 1k, 1,000,000 -> 1M, etc.

The badge directive wraps the existing badge styles and applies the approximate filter to the badge count. Badges typically don't look great with large counts.