### PR TITLE
Multivalue object dropdown fix

### DIFF
--- a/lib/core/api/api-codes.js
+++ b/lib/core/api/api-codes.js
@@ -5,6 +5,10 @@
 
   var availity = root.availity;
 
+  availity.core.factory('avCodesResource', function(AvApiResource) {
+    return new AvApiResource({version: '/v1', url: '/codes'});
+  });
+
   var AvCodesResourceFactory = function(AvApiResource) {
 
     var AvCodesResource = function () {

--- a/lib/core/api/api-codes.js
+++ b/lib/core/api/api-codes.js
@@ -5,10 +5,6 @@
 
   var availity = root.availity;
 
-  availity.core.factory('avCodesResource', function(AvApiResource) {
-    return new AvApiResource({version: '/v1', url: '/codes'});
-  });
-
   var AvCodesResourceFactory = function(AvApiResource) {
 
     var AvCodesResource = function () {

--- a/lib/ui/dropdown/docs/dropdown-ui-demo.js
+++ b/lib/ui/dropdown/docs/dropdown-ui-demo.js
@@ -14,7 +14,7 @@
     ];
     $scope.selectedState = null;
     $scope.selectedHosp = null;
-    $scope.selectedStates = [0, 1];
+    $scope.selectedStates = [{ id: 'WY', name: 'Wyoming' }, { id: 'NM', name: 'New Mexico' }];
 
     $scope.addStates = function() {
       $scope.states.push({id: 'FL', name: 'Florida'});

--- a/lib/ui/dropdown/dropdown.js
+++ b/lib/ui/dropdown/dropdown.js
@@ -114,6 +114,26 @@
       });
     };
 
+    this.getMultiSelected = function(viewValue) {
+      var options = this.collection($scope);
+      var indices = [];
+
+      _.each(viewValue, function(savedObject) {
+        var index = _.findIndex(options, function(value) {
+          var temp = angular.copy(savedObject); // remove hashkeys for comparison
+          return _.matches(temp)(value);
+        });
+        indices.push(index);
+      });
+
+      if(indices.length > 0) {
+        viewValue = indices;
+      }
+
+      return viewValue;
+
+    };
+
     this.setValues = function() {
       var viewValue = self.ngModel.$viewValue;
 
@@ -122,18 +142,7 @@
       }
 
       if(!_.isEmpty(viewValue) && _.isObject(viewValue[0])) {
-        var options = this.collection($scope);
-        var indices = [];
-        _.each(viewValue, function(savedObject) {
-          var index = _.findIndex(options, function(value) {
-            var temp = angular.copy(savedObject); //remove hashkeys for comparison
-            return _.matches(temp)(value);
-          });
-          indices.push(index);
-        });
-        if(indices.length > 0) {
-          viewValue = indices;
-        }
+        viewValue = this.getMultiSelected(viewValue);
       }
 
       $timeout(function() {

--- a/lib/ui/dropdown/dropdown.js
+++ b/lib/ui/dropdown/dropdown.js
@@ -121,7 +121,21 @@
         viewValue = [];
       }
 
-      // var apply = scope.$evalAsync || $timeout;
+      if(!_.isEmpty(viewValue) && _.isObject(viewValue[0])){
+        var options = this.collection($scope);
+        var indices = [];
+        _.each(viewValue, function(savedObject) {
+          var index = _.findIndex(options, function(value) {
+            var temp = angular.copy(savedObject); //remove hashkeys for comparison
+            return _.matches(temp)(value);
+          });
+          indices.push(index);
+        });
+        if(indices.length > 0) {
+          viewValue = indices;
+        }
+      }
+
       $timeout(function() {
         $element
           .select2('val', viewValue);

--- a/lib/ui/dropdown/dropdown.js
+++ b/lib/ui/dropdown/dropdown.js
@@ -121,7 +121,7 @@
         viewValue = [];
       }
 
-      if(!_.isEmpty(viewValue) && _.isObject(viewValue[0])){
+      if(!_.isEmpty(viewValue) && _.isObject(viewValue[0])) {
         var options = this.collection($scope);
         var indices = [];
         _.each(viewValue, function(savedObject) {

--- a/lib/ui/dropdown/tests/dropdown-spec.js
+++ b/lib/ui/dropdown/tests/dropdown-spec.js
@@ -9,6 +9,7 @@ describe('avDropdown', function() {
   // jscs: disable
   var fixtures = {
     'default': '<select name="demoSelect" class="form-control select2" placeholder="Select One" data-av-dropdown data-ng-model="demo.selected" data-ng-options="selection for selection in demo.selections"></select>',
+    'multiple': '<select name="demoSelect" class="form-control select2" placeholder="Select Multiple" data-av-dropdown data-ng-model="demo.selected" multiple data-ng-options="selection for selection in demo.selections"></select>',
     'ajax': '<input type="hidden" name="demoSelect" id="ajaxTest" class="form-control select2" data-av-dropdown data-ng-model="demo.selected" data-placeholder="Select One" data-query="demo.myQuery" data-minimum-input-length="0" data-format-result="demo.myFormatResult" data-format-selection="demo.myFormatResult">'
   };
   // jscs: enable
@@ -96,6 +97,66 @@ describe('avDropdown', function() {
       availity.mock.$scope.$apply();
       availity.mock.flush();
       expect($el.select2('val')).toBe('1');
+
+    });
+
+    it('should update when types are ints for multiselect', function () {
+
+      availity.mock.$scope.demo = {};
+      availity.mock.$scope.demo.selections = [
+        {
+          id: 1,
+          value: 'first'
+        },
+        {
+          id: 2,
+          value: 'second'
+        },
+        {
+          id: 3,
+          value: 'third'
+        }
+      ];
+      availity.mock.$scope.demo.selected = availity.mock.$scope.demo.selections[0];
+
+      $el = availity.mock.compileDirective(fixtures['multiple']);
+
+      availity.mock.flush();
+
+      availity.mock.$scope.demo.selected = [1, 2];
+      availity.mock.$scope.$apply();
+      availity.mock.flush();
+      expect($el.select2('val')).toEqual(['1', '2']);
+
+    });
+
+    it('should update when types are objects for multiselect', function () {
+
+      availity.mock.$scope.demo = {};
+      availity.mock.$scope.demo.selections = [
+        {
+          id: 1,
+          value: 'first'
+        },
+        {
+          id: 2,
+          value: 'second'
+        },
+        {
+          id: 3,
+          value: 'third'
+        }
+      ];
+      availity.mock.$scope.demo.selected = availity.mock.$scope.demo.selections[0];
+
+      $el = availity.mock.compileDirective(fixtures['multiple']);
+
+      availity.mock.flush();
+
+      availity.mock.$scope.demo.selected = [availity.mock.$scope.demo.selections[1], availity.mock.$scope.demo.selections[2]];
+      availity.mock.$scope.$apply();
+      availity.mock.flush();
+      expect($el.select2('val')).toEqual(['1', '2']);
 
     });
 


### PR DESCRIPTION
dropdown multiselect required indices to set the initial state. This allows your ng-model to be an array of objects and it will select those indices in your ng-options and send it to select2 to display.

This change won't run if you have an array of integers. So the original way of setting multiselect still works.