### PR TITLE
Add check for stack in logger so that it is included in error messages

### DIFF
--- a/lib/core/logger/logger.js
+++ b/lib/core/logger/logger.js
@@ -99,6 +99,11 @@
             } else {
               supplantData = args[1];
               message = AvLogger.supplant('{0}{1} - {2}', [now, context, args[0]]);
+              // If the message is an error, there may be a stack included. If so, we
+              // should include the stack in the message to make it more meaningful.
+              if(args[0].stack) {
+                message += args[0].stack;
+              }
             }
             break;
         }

--- a/lib/core/logger/logger.js
+++ b/lib/core/logger/logger.js
@@ -143,9 +143,10 @@
       proto.formatError = function(arg) {
         if (arg instanceof Error) {
           if (arg.stack) {
-            arg = (arg.message && arg.stack.indexOf(arg.message) === -1)
-                ? 'Error: ' + arg.message + '\n' + arg.stack
-                : arg.stack;
+
+            arg = (arg.message && arg.stack.indexOf(arg.message) === -1) ?
+              'Error: ' + arg.message + '\n' + arg.stack : arg.stack;
+
           } else if (arg.sourceURL) {
             arg = arg.message + '\n' + arg.sourceURL + ':' + arg.line;
           }

--- a/lib/core/logger/logger.js
+++ b/lib/core/logger/logger.js
@@ -141,13 +141,13 @@
 
       // https://github.com/angular/angular.js/blob/v1.2.27/src/ng/log.js#L122
       proto.formatError = function(arg) {
-        if (arg instanceof Error) {
-          if (arg.stack) {
+        if(arg instanceof Error) {
+          if(arg.stack) {
 
             arg = (arg.message && arg.stack.indexOf(arg.message) === -1) ?
               'Error: ' + arg.message + '\n' + arg.stack : arg.stack;
 
-          } else if (arg.sourceURL) {
+          } else if(arg.sourceURL) {
             arg = arg.message + '\n' + arg.sourceURL + ':' + arg.line;
           }
         }

--- a/lib/core/logger/logger.js
+++ b/lib/core/logger/logger.js
@@ -95,15 +95,23 @@
             // as the message and the second as array of interpolation variables.
             // The output print will be according to this check.
             if(typeof args[1] === 'string') {
+
               message = AvLogger.supplant("{0}{1} - {2}(\'{3}\')", [now, context, args[0], args[1]]);
+
             } else {
-              supplantData = args[1];
-              message = AvLogger.supplant('{0}{1} - {2}', [now, context, args[0]]);
+
               // If the message is an error, there may be a stack included. If so, we
               // should include the stack in the message to make it more meaningful.
               if(args[0].stack) {
-                message += args[0].stack;
+                var errorMessage = this.formatError(args[0]);
+                message = AvLogger.supplant('{0}{1} - {2}', [now, context, errorMessage]);
+                supplantData = args[1];
+
+              }else {
+                supplantData = args[1];
+
               }
+
             }
             break;
         }
@@ -129,6 +137,20 @@
 
       proto.debug = function() {
         this._log('debug', arguments);
+      };
+
+      // https://github.com/angular/angular.js/blob/v1.2.27/src/ng/log.js#L122
+      proto.formatError = function(arg) {
+        if (arg instanceof Error) {
+          if (arg.stack) {
+            arg = (arg.message && arg.stack.indexOf(arg.message) === -1)
+                ? 'Error: ' + arg.message + '\n' + arg.stack
+                : arg.stack;
+          } else if (arg.sourceURL) {
+            arg = arg.message + '\n' + arg.sourceURL + ':' + arg.line;
+          }
+        }
+        return arg;
       };
 
       proto.error = function() {


### PR DESCRIPTION
There may be a more appropriate place for this code (perhaps in the error method, since I don't think we would have stack traces in any other method call), but this fix worked for me locally. Debugging is now possible!