### PR TITLE
Only show popover on load if element is in view

### DIFF
--- a/lib/ui/popover/popover.js
+++ b/lib/ui/popover/popover.js
@@ -61,12 +61,22 @@
       $element.popover('destroy');
     };
 
+    this.elementInView = function() {
+      var rect = $element.length > 0 ? $element[0].getBoundingClientRect() : {};
+
+      return (
+        rect.top >= 0 &&
+        rect.left >= 0 &&
+        rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+        rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+      );
+    }
 
     this.init = function() {
 
       this.listeners();
 
-      if($scope.showOnLoad) {
+      if($scope.showOnLoad && this.elementInView()) {
 
         this.show();
 


### PR DESCRIPTION
Fix for issue #153 , this change will cause the popover to show only if it is in the current viewport.