### PR TITLE
Fixes for datepicker formatters

### DIFF
--- a/lib/ui/datepicker/datepicker.js
+++ b/lib/ui/datepicker/datepicker.js
@@ -71,7 +71,7 @@
 
     this.setValue = function() {
 
-      var viewValue = self.ngModel.$modelValue;
+      var viewValue = self.ngModel.$viewValue;
       var plugin = this.plugin();
 
       if(!viewValue || !plugin) {
@@ -98,20 +98,21 @@
       return ngModel;
     };
 
-    this.modelToView = function() {
-      var viewValue = $.fn.datepicker.DPGlobal.formatDate(self.ngModel.$modelValue, self.options.format, 'en');
+    this.modelToView = function(isoWrap) {
+      var viewValue = $.fn.datepicker.DPGlobal.formatDate(isoWrap, self.options.format, 'en');
       return viewValue;
     };
 
     this.wrapIsoDate = function() {
       var date = self.ngModel.$modelValue;
+      var isoWrap;
 
-      if(date !== undefined && date !== null && !moment.isDate(date)) {
+      if(date !== undefined && date !== null) {
         var m = moment(date);
-        self.ngModel.$modelValue = m.isValid() ? m.toDate() : null;
+        isoWrap = m.isValid() ? m.toDate() : null;
       }
 
-      return self.ngModel.$modelValue;
+      return isoWrap;
     };
 
     this.viewToModel = function() {

--- a/lib/ui/datepicker/datepicker.js
+++ b/lib/ui/datepicker/datepicker.js
@@ -8,6 +8,7 @@
   var availity = root.availity;
 
   availity.ui.provider('avDatepickerConfig', function() {
+
     var config = {
       autoclose: true,
       todayHighlight: true,
@@ -22,6 +23,7 @@
     this.$get = function() {
       return angular.copy(config);
     };
+
   });
 
   // Options: http://bootstrap-datepicker.readthedocs.org/en/latest/options.html
@@ -104,6 +106,7 @@
     };
 
     this.wrapIsoDate = function() {
+
       var date = self.ngModel.$modelValue;
       var isoWrap;
 

--- a/lib/ui/datepicker/tests/datepicker-spec.js
+++ b/lib/ui/datepicker/tests/datepicker-spec.js
@@ -14,11 +14,13 @@ describe('avDatepicker', function() {
   });
 
   beforeEach(module(function(avDatepickerConfigProvider) {
+
     avDatepickerConfig = avDatepickerConfigProvider;
     avDatepickerConfig.set({
       daysOfWeekDisabled: '0',
       datesDisabled: '1'
     });
+
   }));
 
   availity.mock.directiveSpecHelper();
@@ -86,6 +88,21 @@ describe('avDatepicker', function() {
     $el = availity.mock.compileDirective(fixtures['default']);
 
     expect($el.val()).toBe('12/31/2014');
+  });
+
+  it('should NOT update $modelValue when calling wrapIsoDate()', function() {
+
+    availity.mock.$scope.selectedDate = '2014-12-31T23:00:00Z';
+    angular.mock.TzDate(+1, '2014-12-31T23:00:00Z');
+    $el = availity.mock.compileDirective(fixtures['default']);
+
+    var ngModel = $el.data('$ngModelController');
+    var controller = $el.data('$avDatepickerController');
+
+    ngModel.$modelValue = '2014-11-31T23:00:00Z';
+    controller.wrapIsoDate();
+
+    expect(ngModel.$modelValue).toBe('2014-11-31T23:00:00Z');
   });
 
   it('should correctly ignore undefined date from MODEL', function() {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Availity/availity-angular.git"
+    "url": "ssh://git@github.com:Availity/availity-angular.git"
   },
   "author": "Robert McGuinness <robert.mcguinness.iii@gmail.com> (http://robmcguinness.com/)",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "ssh://git@github.com:Availity/availity-angular.git"
+    "url": "https://github.com/Availity/availity-angular.git"
   },
   "author": "Robert McGuinness <robert.mcguinness.iii@gmail.com> (http://robmcguinness.com/)",
   "authors": [
@@ -19,11 +19,11 @@
     },
     {
       "name": "Bobby Bennett",
-      "email": "bbennett8609@gmail.com"
+      "email": "Bobby.Bennett@availity.com"
     },
     {
       "name": "Javier Fernandez-Ivern",
-      "email": "javier@ivern.org"
+      "email": "Javier.FernandezIvern@availity.com"
     }
   ],
   "license": "MIT",


### PR DESCRIPTION
The existing code causes an issue in the scenario where the model is set prior to initialization (i.e. editing an existing date). The old code used formatters to change the model value. However, this in turn would cause the watcher in angular to trigger, and the formatters would once again kick in, as to them it looks like there was a model change. This continues indefinitely.

There really isn't a need to change the model value. Rather, we just let the formatter chain to do the work for us. In other words, let one formatter pass along the object needed by the next.