### PR TITLE
Return the promise from modal scope calls.

### DIFF
--- a/lib/ui/modal/modal.js
+++ b/lib/ui/modal/modal.js
@@ -159,15 +159,15 @@
       var scope = this.options.scope;
 
       scope.modalShow = function() {
-        self.show();
+        return self.show();
       };
 
       scope.modalToggle = function() {
-        self.toggle();
+        return self.toggle();
       };
 
       scope.modalHide = function() {
-        self.hide();
+        return self.hide();
       };
 
     };


### PR DESCRIPTION
Allow the completion of the asynchronous events to be determined by actually returning the promise.