### PR TITLE
Enhance api resource URL building

### DIFF
--- a/lib/core/api/api-factory.js
+++ b/lib/core/api/api-factory.js
@@ -169,9 +169,31 @@
       return promise;
     };
 
+    proto.normalize = function(url) {
+      return url
+        .replace(/[\/]+/g, '/')
+        .replace(/\/$/, '');
+    };
+
+    proto.join = function () {
+      var joined = [].slice.call(arguments, 0).join('/');
+      return this.normalize(joined);
+    };
+
     proto._getApiUrl = function(id) {
+
       id = id ? '/' + id : '';
-      return this.options.prefix + this.options.path + this.options.level + this.options.resourceGroup + this.options.version + this.options.url + id + this.options.suffix;
+
+      var url = this.join(
+        this.options.prefix,
+        this.options.path,
+        this.options.level,
+        this.options.resourceGroup,
+        this.options.version,
+        this.options.url,
+        id);
+
+      return url + this.options.suffix;
     };
 
     proto.create = function(data, config) {

--- a/lib/core/api/tests/api-factory-spec.js
+++ b/lib/core/api/tests/api-factory-spec.js
@@ -106,17 +106,36 @@ describe('AvApiResource', function() {
 
     });
 
-    it('should build resources with `public` and `internal` and resourceGroup `epdm` and version 2', function() {
+    it('should build resources with `public` and `internal` and resourceGroup `foo` and version 2', function() {
 
       var users = new AvApiResource({
         prefix: '/public',
         url: '/users',
         version: '/v2',
         level: '/internal',
-        resourceGroup: '/epdm'
+        resourceGroup: '/foo'
       });
 
-      expect(users._getUrl()).toBe('/public/api/internal/epdm/v2/users');
+      expect(users._getUrl()).toBe('/public/api/internal/foo/v2/users');
+
+    });
+
+    it('should build resource url with path parameters missing slash "/" character', function() {
+
+      var api1 = new AvApiResource({
+        version: '/v1',
+        level: 'utils',
+        url: 'users'
+      });
+
+      var api2 = new AvApiResource({
+        version: 'v1',
+        level: 'utils',
+        url: 'users'
+      });
+
+      expect(api1._getUrl()).toBe('/api/utils/v1/users');
+      expect(api2._getUrl()).toBe('/api/utils/v1/users');
 
     });
 


### PR DESCRIPTION
This allows `AvApiResource` to intelligently build ulrs by joining option path segments properly even when the segements are misssing the slash `\` character