### PR TITLE
Added ability for AvModal to be created specifying a controller rather than a scope

### DIFF
--- a/lib/ui/modal/docs/modal-ui-demo.html
+++ b/lib/ui/modal/docs/modal-ui-demo.html
@@ -60,7 +60,30 @@ availity.demo.controller('ModalCtrl', function ($scope, AvModal) {
 <div av-modal size="sm">
   ...
 </div>
+
 </code>
+
+<h3 class="guide-subsection-title">Modal With Controller</h3>
+<div class="guide-example" data-ng-controller="ModalCtrl">
+  <button class="btn btn-default btn-sm" data-ng-click="modalOpenWithController()">
+    Modal With Dedicated Controller
+  </button>
+</div>
+<code class="language-javascript">
+availity.demo.controller('ModalCtrl', function ($scope, AvModal) {
+  $scope.modalOpenWithController = function() {
+    AvModal.create({
+      show: true,
+      controller: 'ModalSpecificController',
+      controllerAs: 'vm',
+      locals: {
+        someValue: 'This is a value passed in using locals, it could be params passed from the external scope required by the modal.'
+      }
+    });
+  };
+});
+</code>
+
 
 <h3 class="guide-subsection-title">Modal Manager</h3>
 <div class="guide-example" ng-controller="ModalCtrl">

--- a/lib/ui/modal/docs/modal-ui-demo.js
+++ b/lib/ui/modal/docs/modal-ui-demo.js
@@ -58,6 +58,20 @@
 
     };
 
+    $scope.modalOpenWithController = function () {
+      console.log('in demo create modal with controller');
+
+      AvModal.create({
+        show: true,
+        templateUrl: 'templates/modal-with-controller-template.html',
+        controller: 'ModalSpecificController',
+        controllerAs: 'vm',
+        locals: {
+          someValue: 'This is a value passed in using locals, they become injectable values into the controller based on their key name.'
+        }
+      });
+    };
+
     $scope.routeChange = function()  {
 
       AvModal.create({
@@ -68,6 +82,13 @@
 
     };
 
+  });
+
+  availity.demo.controller('ModalSpecificController', function (someValue) {
+    var vm = this;
+
+    vm.myMessage = 'This is a message from a controller specified on AvModal';
+    vm.localsMessage = someValue;
   });
 
   availity.demo.config(function($stateProvider) {

--- a/lib/ui/modal/docs/modal-with-controller-template.html
+++ b/lib/ui/modal/docs/modal-with-controller-template.html
@@ -1,0 +1,15 @@
+<div data-av-modal data-size="lg">
+  <div class="modal-header">
+    <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
+    <h4 class="modal-title" id="myModalLabel">Modal title</h4>
+  </div>
+  <div class="modal-body">
+
+    <p data-ng-bind="vm.myMessage"></p>
+    <p data-ng-bind="vm.localsMessage"></p>
+
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
+  </div>
+</div>

--- a/lib/ui/modal/modal.js
+++ b/lib/ui/modal/modal.js
@@ -8,6 +8,9 @@
 
     OPTIONS: {
       scope: null,
+      controller: null,
+      controllerAs: null,
+      locals: null,
       templateUrl: null,
       template: null,
       id: null,
@@ -89,7 +92,7 @@
 
   });
 
-  var ModalFactory = function($rootScope, $timeout, $compile, AV_MODAL, avTemplateCache, $q, avModalManager) {
+  var ModalFactory = function($rootScope, $timeout, $compile, $controller, $log, AV_MODAL, avTemplateCache, $q, avModalManager) {
 
     var Modal = function(options) {
 
@@ -98,7 +101,7 @@
       this.templateDefer = $q.defer();
       this.templatePromise = this.templateDefer.promise;
 
-      this.options = angular.extend({}, AV_MODAL.OPTIONS, {scope: $rootScope.$new()}, options);
+      this.options = this._buildOptions(options);
 
       avTemplateCache.get(options).then(function(template) {
         self.options.template = template;
@@ -112,6 +115,29 @@
     };
 
     var proto = Modal.prototype;
+
+    proto._buildOptions = function (userOptions) {
+      var options = angular.extend({}, AV_MODAL.OPTIONS, userOptions);
+
+      if (!options.scope) {
+        options.scope = $rootScope.$new();
+      }
+
+      if (options.controller) {
+        var locals = angular.extend({ $scope: options.scope }, options.locals);
+
+        var controller = $controller(options.controller, locals);
+
+        if (options.controllerAs) {
+          if (options.scope[options.controllerAs]) {
+            $log.warn('Overwriting ' + options.controllerAs + 'on scope with AvModal controllerAs, consider passing in no scope, or specifying a different controllerAs than the existing controller')
+          }
+          options.scope[options.controllerAs] = controller;
+        }
+      }
+
+      return options;
+    };
 
     proto._build = function() {
 

--- a/lib/ui/modal/tests/modal-spec.js
+++ b/lib/ui/modal/tests/modal-spec.js
@@ -178,4 +178,51 @@ describe('AvModal', function() {
 
   });
 
+  it('should instantiate a controller if specified', function () {
+    modal = new AvModal({
+      template: template,
+      scope: availity.mock.$scope,
+      controller: availity.mock.spy
+    });
+
+    expect(availity.mock.spy).toHaveBeenCalled();
+  });
+
+  it('should attach controller to scope if controllerAs is specified', function () {
+    var controllerInstance = {};
+    availity.mock.spy.and.returnValue(controllerInstance);
+
+    modal = new AvModal({
+      template: template,
+      scope: availity.mock.$scope,
+      controller: availity.mock.spy,
+      controllerAs: 'vm'
+    });
+
+    expect(availity.mock.$scope.vm).toBe(controllerInstance);
+  });
+
+  it('should make locals available to be injected into the controller', function () {
+    var controllerCalled = false;
+    var expectedInjectedLocal = {};
+
+    function MyController(localInjectedValue) {
+      expect(localInjectedValue).toBe(expectedInjectedLocal);
+
+      controllerCalled = true;
+    }
+
+    modal = new AvModal({
+      template: template,
+      scope: availity.mock.$scope,
+      controller: MyController,
+      locals: {
+        localInjectedValue: expectedInjectedLocal
+      }
+    });
+
+    // Ensure the expect statement inside MyController was hit
+    expect(controllerCalled).toBe(true);
+  });
+
 });


### PR DESCRIPTION
Support for `controller` and `controllerAs` properties on the AvModal config object, that behave the same as on a route or a directive.  

You can pass a function or a name of a controller registered with `angular.module().controller()`.  Specifying `controllerAs` will attach the controller to the scope with the given name.

There is also a `locals` option, which specifies values that can be injected into that specific instance of the controller (`$scope` is included by default, as is done in routes and directives).  This is a less common, but very standard feature of angular.