### PR TITLE
Fix for issue #175, where supplant was messing up angular error messages

### DIFF
--- a/lib/core/logger/logger.js
+++ b/lib/core/logger/logger.js
@@ -24,11 +24,14 @@
 
       var proto = AvLogger.prototype;
 
-      AvLogger.supplant = function(str, o) {
+      AvLogger.supplant = function(str, supplantData) {
+        if (!supplantData) {
+          return str;
+        }
 
-        var _supplant = function (a, b) {
-          var r = o[b];
-          return r;
+        var _supplant = function (match, key) {
+          var result = supplantData[key];
+          return result;
         };
 
         return str.replace(/\{([^{}]*)\}/g, _supplant);

--- a/lib/core/logger/tests/logger-spec.js
+++ b/lib/core/logger/tests/logger-spec.js
@@ -1,0 +1,84 @@
+/*global it, inject, module, spyOn, beforeEach, expect, describe */
+describe('avLogger', function () {
+  'use strict';
+
+  var AvLogger;
+  var logger;
+  var formattedTimestamp = '';
+  var logMock = {
+    foo: 'bar',
+    log: function () {},
+    error: function () {}
+  };
+
+  beforeEach(module('availity', function (_AvLoggerProvider_) {
+    _AvLoggerProvider_.enabled(true);
+  }));
+  beforeEach(inject(function (_AvLogger_) {
+    AvLogger = _AvLogger_;
+    logger = new AvLogger('', logMock);
+
+    spyOn(AvLogger, 'getFormattedTimestamp').and.callFake(function () {
+      return formattedTimestamp;
+    });
+  }));
+
+  describe('logging', function () {
+    it('calls the delegate\'s log method', function () {
+      spyOn(logMock, 'log');
+      formattedTimestamp = '111';
+
+      logger.log('foo');
+
+      expect(logMock.log).toHaveBeenCalledWith('111 - foo');
+    });
+
+    it('calls the delegate\'s error method', function () {
+      spyOn(logMock, 'error');
+      formattedTimestamp = '111';
+
+      logger.error('foo');
+
+      expect(logMock.error).toHaveBeenCalledWith('111 - foo');
+    });
+
+    it('logs angular errors with a stack', function () {
+      spyOn(logMock, 'error');
+      formattedTimestamp = '111';
+      var err = new Error('Foo');
+      err.stack = 'bar';
+
+      logger.error(err, undefined); // Angular passes along a 'cause' param that is usually undefined
+
+      expect(logMock.error).toHaveBeenCalledWith('111 - Error: Foo\nbar');
+    });
+
+    it('handles logging angular errors with {} in them.', function () {
+      spyOn(logMock, 'error');
+      formattedTimestamp = '111';
+      var err = new Error('Foo {}');
+      err.stack = 'bar';
+
+      logger.error(err, undefined); // Angular passes along a 'cause' param that is usually undefined
+
+      expect(logMock.error).toHaveBeenCalledWith('111 - Error: Foo {}\nbar');
+    });
+
+    // TODO: More tests around scenarios where 'cause' is not undefined, as I think that might potentially break the logic in _log
+  });
+
+  describe('supplant', function () {
+    it('should replace interpolated values with the appropriate array element', function () {
+      var actual = AvLogger.supplant('my {0} message {1}', ['interpolated', 'works']);
+
+      expect(actual).toBe('my interpolated message works');
+    });
+
+    it('should return the raw string when no supplant data is passed in', function () {
+      var actual = AvLogger.supplant('no supplant data', undefined);
+
+      expect(actual).toBe('no supplant data');
+    });
+  });
+
+});


### PR DESCRIPTION
Fixed bug in supplant where it would incorrectly interpret {} in angular error messages as an attempt to supplant undefined data.

I ended up going with the simple null check in the supplant function.  It's a good safe way to correctly handle null supplantData in any scenario that calls supplant.  While I feel that in this particular scenario, we shouldn't even be attempting to supplant, this fixes the problem, and is an overall improvement to the method.

Looking over the logic that chose to call supplant in the first place, I'm not entirely certain that it is correctly in alignment with the API of `$log`, and might run into further issues in other edge cases.  Such as if an error comes in with a stack, but as only one arg, or if a 'cause' is supplied as the second parameter to `$log.error()` via the default `$exceptionHandler`.  Both of those cases would take us down branches that don't correctly format error messages.  But I don't know enough about the expected use cases for AvLogger to change up the logic without possibly introducing breaking changes.