### PR TITLE
Handle different formats so moment doesn't bark at us

### DIFF
--- a/lib/ui/datepicker/datepicker.js
+++ b/lib/ui/datepicker/datepicker.js
@@ -111,7 +111,17 @@
       var isoWrap;
 
       if(date !== undefined && date !== null) {
-        var m = moment(date);
+        var m;
+
+        if (date instanceof Date) {
+          m = moment(date);
+        } else {
+          // We actually can't guarantee that this string is ISO-8601 compliant. If it isn't, passing it to moment without a format throws a
+          // deprecation warning. See https://github.com/moment/moment/issues/1407 for more details. These formats seem to be the most commonly
+          // used in our code. (ISO 8601 accepts pretty much anything in YYYY-MM-DD format, with optional time portion that we ignore.)
+          m = moment(date, [ moment.ISO_8601, 'M/D/YYYY' ]);
+        }
+
         isoWrap = m.isValid() ? m.toDate() : null;
       }
 

--- a/lib/ui/datepicker/tests/datepicker-spec.js
+++ b/lib/ui/datepicker/tests/datepicker-spec.js
@@ -1,4 +1,4 @@
-/* global beforeEach, availity, afterEach, expect, module, describe, it */
+/* global beforeEach, availity, afterEach, expect, module, describe, it, spyOn, console */
 /**
  * Inspiration https://github.com/mgcrea/angular-strap/blob/v0.7.8/test/unit/directives/datepickerSpec.js
  */
@@ -13,6 +13,14 @@ describe('avDatepicker', function() {
     module('availity.ui');
   });
 
+  beforeEach(function() {
+    moment.deprecationHandler = function(name, message) {
+      console.info('Received call to moment.deprecationHandler with name ' + name + ' and message ' + message);
+    };
+
+    spyOn(moment, 'deprecationHandler');
+  });
+
   beforeEach(module(function(avDatepickerConfigProvider) {
 
     avDatepickerConfig = avDatepickerConfigProvider;
@@ -22,6 +30,10 @@ describe('avDatepicker', function() {
     });
 
   }));
+
+  afterEach(function() {
+    moment.deprecationHandler = null; // somebody needs to talk to the moment.js guys about undefined/null and ==/===
+  });
 
   availity.mock.directiveSpecHelper();
   var $el;
@@ -88,6 +100,44 @@ describe('avDatepicker', function() {
     $el = availity.mock.compileDirective(fixtures['default']);
 
     expect($el.val()).toBe('12/31/2014');
+  });
+
+  it('should correctly initialize ISO 8601 short date from MODEL', function() {
+    availity.mock.$scope.selectedDate = '2014-12-31';
+    angular.mock.TzDate(+1, '2014-12-31');
+    $el = availity.mock.compileDirective(fixtures['default']);
+
+    expect($el.val()).toBe('12/31/2014');
+  });
+
+  it('should correctly initialize formatted date from MODEL', function() {
+    availity.mock.$scope.selectedDate = '6/4/2016';
+    $el = availity.mock.compileDirective(fixtures['default']);
+
+    expect($el.val()).toBe('06/04/2016');
+    expect(moment.deprecationHandler).not.toHaveBeenCalled();
+  });
+
+  it('should correctly initialize zero-padded formatted date from MODEL', function() {
+    availity.mock.$scope.selectedDate = '06/04/2016'; // Make sure that moment honors this as M/D/YYYY
+    $el = availity.mock.compileDirective(fixtures['default']);
+
+    expect($el.val()).toBe('06/04/2016');
+    expect(moment.deprecationHandler).not.toHaveBeenCalled();
+  });
+
+  it('should not throw deprecation warning on string date from MODEL', function() {
+    availity.mock.$scope.selectedDate = '6/4/2016';
+    $el = availity.mock.compileDirective(fixtures['default']);
+
+    expect(moment.deprecationHandler).not.toHaveBeenCalled();
+  });
+
+  it('should not accept unrecognized format from MODEL', function() {
+    availity.mock.$scope.selectedDate = 'monkey_business';
+    $el = availity.mock.compileDirective(fixtures['default']);
+
+    expect($el.val()).toBe('');
   });
 
   it('should NOT update $modelValue when calling wrapIsoDate()', function() {


### PR DESCRIPTION
This is something that I've been seeing in our browser console every now and then, and finally got around to tracking down.

We have dates that sometimes come in as MM/DD/YYYY, which causes this momentjs deprecation warning.