### PR TITLE
help prevent explosions

### DIFF
--- a/lib/ui/block/block.js
+++ b/lib/ui/block/block.js
@@ -68,7 +68,7 @@
       var origGetFn = blockUI.instances.get;
       blockUI.instances.get = function(id) {
         var instance = origGetFn(id);
-        if(!instance.avModifications) {
+        if(instance && !instance.avModifications) {
           modifyBlockInstances(id, instance);
         }
         return instance;


### PR DESCRIPTION
So, I'm trying to mock blockUI in my unit tests so I can get coverage, but this blows up if I mock it and return an undefined instance.

Also open to discussion on if there's something else we should be doing instead.

if I do a blockUI.instances.get and it doesn't find the instance. What should I expect to be returned from the get?
