### PR TITLE
Fix invalid error messges on page load for form validation

### DIFF
--- a/lib/core/validation/validator.js
+++ b/lib/core/validation/validator.js
@@ -92,7 +92,7 @@
 
         var ruleConfig = rules[key];
         if(!ruleConfig) {
-          $log.error('Failed to get rules key [' + key + '].  Forms must be tagged with a rules set name for validation to work.');
+          $log.warn('Could not resolve the form rules key [' + key + '].  This can happen when the rules key is inside a promise and the key value has not resolved on page load.');
           return;
         }
 

--- a/lib/ui/validation/field.js
+++ b/lib/ui/validation/field.js
@@ -79,11 +79,17 @@
       var rulesKey = self.avValForm.rulesKey;
       var results = avVal.validate(rulesKey, $element, value, self.rule);
 
-      // validate function is called within the context of angular so fn.call and set the context
-      // to "this"
+
+      // Results can be undefined if the form validation key is not resolved on page load due
+      // to promises.  When the promise resolves the validation on the form should re-run with
+      // valid results.
       if(results) {
+
+        // The validate function is called within the context of angular so fn.call and set the context
+        // to "this"
         self.updateModel.call(self, results);
         self.updateView.call(self);
+
       }
 
       return results;

--- a/lib/ui/validation/field.js
+++ b/lib/ui/validation/field.js
@@ -81,8 +81,10 @@
 
       // validate function is called within the context of angular so fn.call and set the context
       // to "this"
-      self.updateModel.call(self, results);
-      self.updateView.call(self);
+      if(results) {
+        self.updateModel.call(self, results);
+        self.updateView.call(self);
+      }
 
       return results;
     };


### PR DESCRIPTION
Fix invalid error messages displaying in console when the form validation key has not resolved.  This issue can happen when the form validation key is resolved inside a promise.  Fixes #237