### PR TITLE
Set form validity when element is removed from a possibly invalid ele…

### DIFF
--- a/lib/ui/validation/form.js
+++ b/lib/ui/validation/form.js
@@ -52,7 +52,9 @@
       if(id && this.violations[id]) {
         delete this.violations[id];
       }
-      this.ngForm.$setValidity('av', _.isEmpty(this.violations));
+      if(_.isEmpty(this.violations)) {
+        this.ngForm.$setValidity('av', _.isEmpty(this.violations));
+      }
     };
 
     this.reset = function() {

--- a/lib/ui/validation/form.js
+++ b/lib/ui/validation/form.js
@@ -53,7 +53,7 @@
         delete this.violations[id];
       }
       if(_.isEmpty(this.violations)) {
-        this.ngForm.$setValidity('av', _.isEmpty(this.violations));
+        this.ngForm.$setValidity('av', true);
       }
     };
 

--- a/lib/ui/validation/form.js
+++ b/lib/ui/validation/form.js
@@ -52,6 +52,7 @@
       if(id && this.violations[id]) {
         delete this.violations[id];
       }
+      this.ngForm.$setValidity('av', _.isEmpty(this.violations));
     };
 
     this.reset = function() {


### PR DESCRIPTION
There is an issue with the form validation that prevents a form from being submitted if an element has a violation is removed from the form.  The form validity never resets.  I added I check to set the validity in the unrecord method for an empty list of violations.
