### PR TITLE
Add error log limiter to prevent slamming the API with duplicate errors

### DIFF
--- a/lib/core/analytics/analytics-exceptions.js
+++ b/lib/core/analytics/analytics-exceptions.js
@@ -13,7 +13,7 @@
     TYPES: {
       EXCEPTION: 'exception'
     },
-    REPEAT_THROTTLE_TIME: 5000
+    REPEAT_LIMIT_TIME: 5000
   });
 
   availity.core.provider('avExceptionAnalytics', function() {
@@ -133,7 +133,7 @@
         var lastTimestamp = this.messageTimestampMap[message];
         var isRepeat = false;
 
-        if (lastTimestamp && timestamp.diff(lastTimestamp) < AV_EXCEPTIONS.REPEAT_THROTTLE_TIME) {
+        if (lastTimestamp && timestamp.diff(lastTimestamp) < AV_EXCEPTIONS.REPEAT_LIMIT_TIME) {
           isRepeat = true;
         }
 

--- a/lib/core/analytics/analytics-exceptions.js
+++ b/lib/core/analytics/analytics-exceptions.js
@@ -12,7 +12,8 @@
     },
     TYPES: {
       EXCEPTION: 'exception'
-    }
+    },
+    REPEAT_THROTTLE_TIME: 5000
   });
 
   availity.core.provider('avExceptionAnalytics', function() {
@@ -52,6 +53,7 @@
           self.onError(stacktrace);
         });
 
+        this.messageTimestampMap = {};
       };
 
       proto.prettyPrint = function(stacktrace) {
@@ -113,10 +115,30 @@
           return;
         }
 
+        // If we've already logged this error recently, don't log it again (no need to spam the API)
+        if (this._isRepeatError(exception)) {
+          return;
+        }
+
         var stacktrace = TraceKit.computeStackTrace(exception);
 
         return this.onError(stacktrace);
 
+      };
+
+      // Check to see if this error was reported within the last 5 seconds
+      proto._isRepeatError = function(exception) {
+        var timestamp = moment();
+        var message = exception.message;
+        var lastTimestamp = this.messageTimestampMap[message];
+        var isRepeat = false;
+
+        if (lastTimestamp && timestamp.diff(lastTimestamp) < AV_EXCEPTIONS.REPEAT_THROTTLE_TIME) {
+          isRepeat = true;
+        }
+
+        this.messageTimestampMap[message] = timestamp;
+        return isRepeat;
       };
 
       return new AvExceptionAnalytics();

--- a/lib/core/analytics/tests/analytics-exceptions-spec.js
+++ b/lib/core/analytics/tests/analytics-exceptions-spec.js
@@ -62,6 +62,14 @@ describe('avExceptionAnalyticsProvider', function() {
       expect(message.errorMessage).toBe('mock error');
     });
 
+    it('should not track rapid exceptions more than once', function() {
+      $exceptionHandler(exception);
+      $exceptionHandler(exception);
+      expect(service.trackEvent.calls.count()).toEqual(2);
+      expect(service.onError.calls.count()).toEqual(1);
+      expect(service.log.calls.count()).toEqual(1);
+    });
+
   });
 
 });


### PR DESCRIPTION
There isn't much value in logging hundreds or thousands of duplicate errors. This will prevent a given error from being logged too frequently.