### PR TITLE
allows fields to get av-val-show from the form

### DIFF
--- a/lib/ui/validation/field.js
+++ b/lib/ui/validation/field.js
@@ -199,6 +199,7 @@
         var avValField = controllers[2];
 
         var avValOn = scope.avValOn || avValForm.avValOn || 'input';
+        scope.avValShow = scope.avValShow || avValForm.avValShow || null;
 
         if(!ngModel && !rule) {
           $log.error('avValField requires ngModel and a validation rule to run.');

--- a/lib/ui/validation/form.js
+++ b/lib/ui/validation/form.js
@@ -121,10 +121,11 @@
             });
 
             // Allow form attributes to define the validation behavior of the form fields
-            // inside it.  If `av-val-on` or `av-val-debounce` are on the form then all form
+            // inside it.  If `av-val-on`, `av-val-debounce`, or `av-val-show` are on the form then all form
             // fields inside the form would inherit this behavior.
             avForm.avValOn = iAttrs.avValOn || null;
             avForm.avValDebounce = iAttrs.avValDebounce || null;
+            avForm.avValShow = scope.$eval(iAttrs.avValShow) || null;
             // Allows fields to update with invalid data for dirty form saving
             avForm.avValInvalid = iAttrs.avValInvalid || false;
 

--- a/lib/ui/validation/tests/field-spec.js
+++ b/lib/ui/validation/tests/field-spec.js
@@ -77,11 +77,10 @@ describe('avValField', function() {
   });
 
   it('should have .has-error class on form group when options.show === true', function() {
-    availity.mock.$scope.myForm.showOnLoad.$setViewValue('1');
     availity.mock.$scope.$digest();
 
     var formGroup = $('#showOnLoadFormGroup');
-    expect(availity.mock.$scope.myForm.invalidAllowed.$invalid).toBe(true);
+    expect(availity.mock.$scope.myForm.showOnLoad.$invalid).toBe(true);
     expect(formGroup.hasClass('has-error')).toBeTruthy();
   });
 

--- a/lib/ui/validation/tests/form-spec.js
+++ b/lib/ui/validation/tests/form-spec.js
@@ -103,6 +103,59 @@ describe('avForm', function() {
     expect(availity.mock.$scope.demo.invalidAllowed).toBe('1');
   });
 
+  it('should immediately create an error for firstName', function() {
+    var template = '' +
+    '<form name="myForm" ng-submit="submit()" data-av-val-form="demo.rules" data-av-val-show="true">' +
+      '<div id="showOnLoadFormGroup" class="form-group">' +
+        '<input data-ng-model="demo.showOnLoad" name="showOnLoad" type="text" data-av-val-field="lastName"/>' +
+        '<p data-av-val-container></p>' +
+      '</div>' +
+    '</form>';
+
+    $el = availity.mock.compileDirective(template);
+    availity.mock.$scope.$digest();
+
+    var formGroup = $('#showOnLoadFormGroup');
+    expect(availity.mock.$scope.myForm.showOnLoad.$invalid).toBe(true);
+    expect(formGroup.hasClass('has-error')).toBeTruthy();
+  });
+
+  it('should not immediately create an error if avValShow variable is false', function() {
+    var template = '' +
+    '<form name="myForm" ng-submit="submit()" data-av-val-form="demo.rules" data-av-val-show="demo.showError">' +
+      '<div id="showOnLoadFormGroup" class="form-group">' +
+        '<input data-ng-model="demo.showOnLoad" name="showOnLoad" type="text" data-av-val-field="lastName"/>' +
+        '<p data-av-val-container></p>' +
+      '</div>' +
+    '</form>';
+
+    availity.mock.$scope.demo.showError = false;
+
+    $el = availity.mock.compileDirective(template);
+    availity.mock.$scope.$digest();
+
+    var formGroup = $('#showOnLoadFormGroup');
+    expect(formGroup.hasClass('has-error')).toBeFalsy();
+  });
+
+  it('should immediately create an error if avValShow variable is true', function() {
+    var template = '' +
+    '<form name="myForm" ng-submit="submit()" data-av-val-form="demo.rules" data-av-val-show="demo.showError">' +
+      '<div id="showOnLoadFormGroup" class="form-group">' +
+        '<input data-ng-model="demo.showOnLoad" name="showOnLoad" type="text" data-av-val-field="lastName"/>' +
+        '<p data-av-val-container></p>' +
+      '</div>' +
+    '</form>';
+
+    availity.mock.$scope.demo.showError = true;
+
+    $el = availity.mock.compileDirective(template);
+    availity.mock.$scope.$digest();
+
+    var formGroup = $('#showOnLoadFormGroup');
+    expect(formGroup.hasClass('has-error')).toBeTruthy();
+  });
+
   describe('submit', function() {
 
     it('should prevent default action', function() {


### PR DESCRIPTION
Allows fields to inherit av-val-show from the form. similar to how av-val-on works. 

Also, it can also be a variable on the form where av-val-show on fields seems to always fire if the attribute exists.