### PR TITLE
Adding postGet function to send data with X-HTTP-Method-Override header set to GET

### DIFF
--- a/src/core/api/README.md
+++ b/src/core/api/README.md
@@ -94,7 +94,7 @@ Every resource created has the methods `get`, `query`, `create`, `update` and `r
 ### Methods
 
 Each method has an after function, ( ex. get has afterGet). These are used to modify the response before it is resolved in the promise.
-Each method that takes in data has a before function in order to modify the data before making the call. 
+Each method that takes in data has a before function in order to modify the data before making the call.
 
 #### get
 
@@ -118,6 +118,13 @@ Create an entity with optional configuration.
 
 ```
 create(data, config)
+```
+
+### postGet
+
+Post call with `X-HTTP-Method-Override = 'GET'`
+```
+postGet(data, config)
 ```
 
 #### update

--- a/src/core/api/README.md
+++ b/src/core/api/README.md
@@ -89,7 +89,7 @@ const module = module.service('app', ['availity'])
     .service('healthplanProvidersResource', HealthplanProvidersResource);
 ```
 
-Every resource created has the methods `get`, `query`, `create`, `update` and `remove`.
+Every resource created has the methods `get`, `query`, `create`, `postGet`, `update` and `remove`.
 
 ### Methods
 

--- a/src/core/api/resource.js
+++ b/src/core/api/resource.js
@@ -227,6 +227,25 @@ class ApiResourceProvider {
 
       }
 
+      postGet(_data, _config) {
+        let data = _data;
+        let config = _config;
+
+        if (!data) {
+          throw new Error('called method without [data]');
+        }
+        if (this.beforeCreate) {
+          data = this.beforePostGet(data);
+        }
+        config = this.config(config);
+        config.method = 'POST';
+        config.headers['X-HTTP-Method-Override'] = 'GET';
+        config.url = this.getUrl();
+        config.data = data;
+
+        return this.request(config, this.afterPostGet);
+      }
+
       get(id, _config) {
 
         let config = _config;
@@ -325,6 +344,13 @@ class ApiResourceProvider {
       }
 
       afterCreate(response) {
+        return response;
+      }
+
+      beforePostGet(data) {
+        return data;
+      }
+      afterPostGet(response) {
         return response;
       }
 

--- a/src/core/api/tests/resource-spec.js
+++ b/src/core/api/tests/resource-spec.js
@@ -241,6 +241,46 @@ describe('AvApiResourceProvider', () => {
 
       });
 
+      describe('create()', () => {
+        it('should post a single resource', () => {
+          $httpBackend.expectPOST('/api/v1/cats').respond(200, responseData);
+
+          cats.create({}).success(data => {
+            expect(data).toBeEqual(responseData);
+            callback();
+          });
+          $httpBackend.flush();
+          expect(callback).toHaveBeenCalled();
+        });
+      });
+
+      describe('postGet()', () => {
+        it('should post a single resource with GET override', () => {
+          $httpBackend.expectPOST('/api/v1/cats').respond(200, responseData);
+
+          const request = spyOn(cats, 'request').and.callThrough();
+
+          const data = { id: 1 };
+          let config = { headers: { 'MyHeader': 'MyValue' } };
+          cats.postGet(data, config).success( result => {
+            expect(result).toBeEqual(responseData);
+            callback();
+          });
+
+          $httpBackend.flush();
+          expect(callback).toHaveBeenCalled();
+
+          config = cats.config(config);
+          config.method = 'POST';
+          config.headers['X-HTTP-Method-Override'] = 'GET';
+          config.url = cats.getUrl();
+          config.data = data;
+
+          expect(request).toHaveBeenCalled();
+          expect(request).toHaveBeenCalledWith(config, jasmine.any(Function));
+        });
+      });
+
       describe('get()', () => {
 
         it('should get a single resource by id', () => {
@@ -271,6 +311,7 @@ describe('AvApiResourceProvider', () => {
 
         });
       });
+
 
       describe('update()', function() {
 


### PR DESCRIPTION
For issue #256 
Recognizing the need to make GET requests with hidden info in the body of the message. 