### PR TITLE
Updating regions resource for api change, updating the getRegions function

### DIFF
--- a/src/core/api/regions.js
+++ b/src/core/api/regions.js
@@ -1,4 +1,3 @@
-import merge from 'lodash.merge';
 import ngModule from '../module';
 
 const AvRegionsFactory = function(AvApiResource, avUsersResource) {
@@ -19,6 +18,7 @@ const AvRegionsFactory = function(AvApiResource, avUsersResource) {
     afterGet(response) {
       return response.data.regions || [];
     }
+
     afterUpdate(response) {
       this.setPageBust();
       return response;
@@ -30,16 +30,19 @@ const AvRegionsFactory = function(AvApiResource, avUsersResource) {
         return this.query(checkedConfig);
       });
     }
+
     checkUser(config = {}) {
+
       config.params = config.params || {};
       if (config.params.userId) {
         return Promise.resolve(config);
       }
+
       return avUsersResource.me()
-      .then(user => {
-        config.params.userId = user.id;
-        return config;
-      });
+        .then(user => {
+          config.params.userId = user.id;
+          return config;
+        });
     }
 
     getCurrentRegion() {

--- a/src/core/api/regions.js
+++ b/src/core/api/regions.js
@@ -24,31 +24,30 @@ const AvRegionsFactory = function(AvApiResource, avUsersResource) {
       return response;
     }
 
-    queryRegions(user, config) {
-
-      const params = {
-        params: {
-          userId: user.id
-        }
-      };
-
-      const conf = merge({}, params, config);
-
-      return this.query(conf);
-
+    getRegions(config) {
+      return this.checkUser(config)
+      .then(checkedConfig => {
+        return this.query(checkedConfig);
+      });
+    }
+    checkUser(config = {}) {
+      config.params = config.params || {};
+      if (config.params.userId) {
+        return Promise.resolve(config);
+      }
+      return avUsersResource.me()
+      .then(user => {
+        config.params.userId = user.id;
+        return config;
+      });
     }
 
     getCurrentRegion() {
-      return this.getRegions()
-        .then(regions => {
-          return regions.find(region => region.currentlySelected);
-        });
-    }
-
-    getRegions(config) {
-      return avUsersResource
-        .me()
-        .then(user => ::this.queryRegions(user, config));
+      return this.query({
+        params: {
+          currentlySelected: true
+        }
+      });
     }
   }
 


### PR DESCRIPTION
the regions api now allows for a currentlySelected parameter, changing the getCurrentRegion function to use this parameter. This will be the only region needed for most cases, so we reduce the payload size as well as prevent an issue with users having more than 50 regions available. 

Updated the getRegions function to only add the userId if one is not already in the config. 