### PR TITLE
Allow bootstrap to set disabled button text color

### DIFF
--- a/src/ui/ui.less
+++ b/src/ui/ui.less
@@ -9,7 +9,6 @@
   &.disabled,
   &[disabled]:hover,
   &.disabled:focus{
-    color: inherit;
     cursor: auto;
     pointer-events: none;
     text-decoration: none;


### PR DESCRIPTION
Fixes text color of disabled buttons with ng-click