### PR TITLE
Fix date format incorrectly using default value when format value pro…

### DIFF
--- a/src/core/validation/validators/date.js
+++ b/src/core/validation/validators/date.js
@@ -14,9 +14,9 @@ ngModule.factory('avValDate', (AV_VAL, avValUtils) => {
       super('dateFormat');
     }
 
-    validate({value, constraint, format}) {
+    validate({value, constraint}) {
 
-      const _format = constraint && format ? format : AV_VAL.DATE_FORMAT.SIMPLE;
+      const _format = constraint && constraint.format ? constraint.format : AV_VAL.DATE_FORMAT.SIMPLE;
       return avValUtils.isEmpty(value) || angular.isDate(value) || moment(value, _format, true).isValid();
     }
 

--- a/src/core/validation/validators/tests/date-spec.js
+++ b/src/core/validation/validators/tests/date-spec.js
@@ -7,12 +7,14 @@ import '../date';
 describe('avValDate', () => {
   let avValDate;
   let contraint;
+  let contraintWithFormat;
 
   beforeEach(angular.mock.module('availity'));
 
   beforeEach(inject((_avValDate_, AV_VAL) => {
     avValDate = _avValDate_;
     contraint = { format: AV_VAL.DATE_FORMAT.SIMPLE };
+    contraintWithFormat = { format: 'MMDDYYYY' };
   }));
 
   it('should be a valid', () => {
@@ -21,6 +23,14 @@ describe('avValDate', () => {
 
   it('should NOT be valid', () => {
     expect(avValDate.validate({value: '20/02/2015', constraint: contraint})).toBe(false);
+  });
+
+  it('custom format, should be a valid', () => {
+    expect(avValDate.validate({value: '02022015', constraint: contraintWithFormat})).toBe(true);
+  });
+
+  it('custom format, should NOT be valid', () => {
+    expect(avValDate.validate({value: '02/02/2015', constraint: contraintWithFormat})).toBe(false);
   });
 
   it('should use default date format if one is not provided', () => {


### PR DESCRIPTION
Date validator was ignoring the format value supplied and always using the default value.