### PR TITLE
Remove premature call to function

### DIFF
--- a/src/ui/dropdown/controller.js
+++ b/src/ui/dropdown/controller.js
@@ -100,7 +100,7 @@ class AvDropdownController {
 
     const objType = typeof obj;
     if (objType === 'function' || (objType === 'object' && obj !== null)) {
-      key = obj.$$hashKey = objType + ':' + (nextUidFn || uuid())();
+      key = obj.$$hashKey = objType + ':' + (nextUidFn || uuid)();
     } else {
       key = objType + ':' + obj;
     }


### PR DESCRIPTION
We don't want to call the "uuid" function within the parenthesis. Otherwise, if nextUidFn is undefined, we will call the result of uuid() (which is a string) as a function.