### PR TITLE
fix(Dropdown): account for 'select as'

### DIFF
--- a/src/ui/dropdown/controller.js
+++ b/src/ui/dropdown/controller.js
@@ -136,7 +136,7 @@ class AvDropdownController {
     const optionValuesKeys = this.getOptionValuesKeys(optionValues);
 
     const index = findIndex(this.collection, item => {
-      return angular.equals(model, item);
+      return angular.equals(model, item) || angular.isObject(item) && this.valueName && angular.equals(model, item[this.valueName]);
     });
 
     const key = (optionValues === optionValuesKeys) ? index : optionValuesKeys[index];


### PR DESCRIPTION
The 'select as' syntax will have the model as a property of the collection items and not the item itself. We need to check if the item matches using the key