### PR TITLE
fix(avExceptionAnalytics): handle no stack (v1)

### DIFF
--- a/lib/core/analytics/analytics-exceptions.js
+++ b/lib/core/analytics/analytics-exceptions.js
@@ -57,10 +57,19 @@
       };
 
       proto.prettyPrint = function(stacktrace) {
-
+        stacktrace = stacktrace || {};
         var message = '';
+        
+        try {
+          if (!stacktrace.stack) {
+            stacktrace.stack = (new Error('force-added stack')).stack;
+            if (stacktrace.stack) {
+              stacktrace.stack = stacktrace.stack.toString();
+            }
+          }
+        } catch (e) {}
 
-        var length = stacktrace.stack.length;
+        var length = stacktrace.stack ? stacktrace.stack.length : 0;
 
         for(var i = 0; i < length; i++) {
           message += [


### PR DESCRIPTION
Backport to v1:
If no stack is on the stack trace, try to make one before giving up.

Closes #280