### PR TITLE
fix(resource): fix incorrect variable check

### DIFF
--- a/src/core/api/resource.js
+++ b/src/core/api/resource.js
@@ -234,7 +234,7 @@ class ApiResourceProvider {
         if (!data) {
           throw new Error('called method without [data]');
         }
-        if (this.beforeCreate) {
+        if (this.beforePostGet) {
           data = this.beforePostGet(data);
         }
         config = this.config(config);


### PR DESCRIPTION
Previous getPost was checking if `this.beforeCreate` existed before calling `this.beforePostGet`
this corrects this by checking for `this.beforePostGet` before calling `this.beforePostGet`.