### PR TITLE
fix(upload-core): add errorCallback

### DIFF
--- a/src/ui/uploads/upload-progress-bar.js
+++ b/src/ui/uploads/upload-progress-bar.js
@@ -4,7 +4,8 @@ import templateUrl from './upload-progress-bar.html';
 ngModule.directive('avUploadProgressBar', () => ({
   restrict: 'E',
   scope: {
-    upload: '='
+    upload: '=',
+    errorCallback: '='
   },
   templateUrl,
   link(scope) {
@@ -16,6 +17,7 @@ ngModule.directive('avUploadProgressBar', () => ({
 
     const error = () => {
       scope.error = true;
+      return scope.errorCallback(scope.upload);
     };
 
     const success = () => {


### PR DESCRIPTION
allows users to add an attribute to the progress bar:
`<av-upload-progress-bar upload="upload" callback="request.onErrorCallback"></av-upload-progress-bar>`
that will be called when/if an error occurs to change the errorMessage

```
onErrorCallback(upload) {
  upload.errorMessage = 'custom error message';
}
```