### PR TITLE
fix(datepicker): use natvie toLowerCase

### DIFF
--- a/src/ui/datepicker/decorator.js
+++ b/src/ui/datepicker/decorator.js
@@ -9,7 +9,7 @@ function dateConfig($provide) {
     directive.compile = () => {
       return {
         pre(scope, element, attr, ctrls) {
-          if (ctrls[0] && angular.lowercase(attr.type) === 'date' && angular.isDefined(attr.avDatepicker)) {
+          if (ctrls[0] && attr.type && attr.type.toLowerCase() === 'date' && angular.isDefined(attr.avDatepicker)) {
             // do not use the default date validation;
           } else {
             link.pre.apply(this, arguments);


### PR DESCRIPTION
angular 1.7 removed `angular.lowercase` (and `angular.uppercase`) to support 1.7 we must use the native `str.toLowerCase`