### PR TITLE
feat(breadcrumbs): add option to use url from space

### DIFF
--- a/src/ui/breadcrumbs/spaces.html
+++ b/src/ui/breadcrumbs/spaces.html
@@ -9,7 +9,7 @@
     </a>
   </li>
   <li ng-if="spaceName">
-    <a href="/public/apps/spaces/#/{{spaceId}}"
+    <a ng-href="{{spaceUrl}}"
       av-analytics-on="click"
       av-analytics-action="click"
       av-analytics-label="{{spaceId}}"

--- a/src/ui/breadcrumbs/spaces.js
+++ b/src/ui/breadcrumbs/spaces.js
@@ -8,6 +8,7 @@ ngModule.directive('avSpacesBreadcrumbs', ($location, avSpacesResource, $log) =>
     replace: true,
     scope: {
       'pageName': '@',
+      'useSpaceUrl': '@?',
       'spaceId': '@?'
     },
     templateUrl,
@@ -25,7 +26,7 @@ ngModule.directive('avSpacesBreadcrumbs', ($location, avSpacesResource, $log) =>
         return query;
       }
 
-      // Find paramter in query string after hash (#)
+      // Find parameter in query string after hash (#)
       if (!spaceId) {
         spaceId = $location.search().spaceId;
       }
@@ -37,9 +38,18 @@ ngModule.directive('avSpacesBreadcrumbs', ($location, avSpacesResource, $log) =>
       }
 
       if (spaceId) {
-        avSpacesResource.get(spaceId).then( response => {
+        avSpacesResource.get(spaceId).then(response => {
           scope.spaceName = response.data.name;
           scope.spaceId = spaceId;
+          scope.spaceUrl = `/public/apps/spaces/#/${spaceId}`;
+          if (scope.useSpaceUrl === 'true') {
+            const urlFromSpace = response.data.link && response.data.link.url;
+            if (!urlFromSpace) {
+              $log.warn(`avSpacesBreadcrumbs has useSpaceUrl option set to true but space has no URL. Using "${scope.spaceUrl}" instead`);
+            } else {
+              scope.spaceUrl = urlFromSpace;
+            }
+          }
         });
       } else {
         $log.warn('avSpacesBreadcrumbs could NOT detect a spaceId through scope or by parsing the URL.');

--- a/src/ui/breadcrumbs/tests/spaces-spec.js
+++ b/src/ui/breadcrumbs/tests/spaces-spec.js
@@ -64,4 +64,20 @@ describe('avSpacesBreadcrumbs', () => {
 
   });
 
+  it('should render url from space when useSpaceUrl option set to true', () => {
+    tester.$httpBackend.expectGET(/\/api\/sdk\/platform\/v1\/spaces\/99999\?sessionBust=\d+/).respond(200, {
+      'id': '99999',
+      'name': 'Acme Texas',
+      'link': {
+        'url': '/public/apps/my-application'
+      }
+    });
+
+    $location.search('spaceId', '99999');
+
+    $el = tester.compileDirective('<div av-spaces-breadcrumbs use-space-url="true"></div>');
+    tester.$httpBackend.flush();
+
+    expect($.trim($el.find('a:eq(1)').attr('href'))).toBe('/public/apps/my-application');
+  });
 });


### PR DESCRIPTION
Useful if you want to use spaces breadcrumbs directive for spaces that are not of type "space"