### PR TITLE
fix(uploads): change button to type of button

### DIFF
--- a/src/ui/uploads/template-password-prompt.html
+++ b/src/ui/uploads/template-password-prompt.html
@@ -11,7 +11,7 @@
           </div>
         </form>
         <div class="modal-footer">
-          <input type="submit" class="btn btn-primary" data-dismiss="modal" ng-click="verifyPassword()" value="Ok"></input>
+          <input type="button" class="btn btn-primary" data-dismiss="modal" ng-click="verifyPassword()" value="Ok"></input>
         </div>
       </div>
     </div>


### PR DESCRIPTION
buttons with no type or a type of submit only are valid within a form. The password request for uploads has a button with type="submit" which is not within a form, this causes issues when the modal itself does appears within a form. Clicking the button will submit the parent form, which is not the password prompt form.